### PR TITLE
Fixed bug in datatable.js to work with mithril v0.1.22

### DIFF
--- a/components/datatable/datatable.js
+++ b/components/datatable/datatable.js
@@ -148,12 +148,6 @@ mc.Datatable = (function () {
 					if (isOld) return;
 					el.addEventListener('click', ctrl.onclick);
 					ctrl._tableEl = el;
-					m.module(el, {
-						controller: function () {
-							return ctrl;
-						},
-						view: dt.contentsView
-					});
 				}
 
 			};
@@ -162,7 +156,8 @@ mc.Datatable = (function () {
 
 			return m(
 				'table',
-				attrs
+				attrs,
+				dt.contentsView(ctrl)
 			);
 
 


### PR DESCRIPTION
Before this was causing mithril to infinitely recurse resulting in a call stack exceeded error
